### PR TITLE
Fix methods in screencap-linux.js

### DIFF
--- a/lib/screencap-linux.js
+++ b/lib/screencap-linux.js
@@ -8,6 +8,7 @@ function screencap(options,fileout) {
 	this.videoCodec = options.videoCodec || "libx264";
 	this.videoBitrate = options.videoBitrate || "1000k";
 	this.audioBitrate = options.audioBitrate || "96k";
+	this.videoFormat = options.videoFormat || "mp4";
 	this.file = path.resolve(""+ fileout +"");
 	this.capture = function(duration) {
 		console.log("Starting Screen Capture: Duration ", duration, " seconds");
@@ -83,6 +84,7 @@ function screencap(options,fileout) {
 		.videoCodec(this.videoCodec)
 		.videoBitrate(this.videoBitrate)
 		.audioBitrate(this.audioBitrate)
+		.format(this.videoFormat)
 		.addOptions([
 			"-movflags frag_keyframe+faststart",
 			"-preset ultrafast",
@@ -109,6 +111,7 @@ function screencap(options,fileout) {
 		ffmpeg()
 		.videoBitrate(this.videoBitrate)
 		.audioBitrate(this.audioBitrate)
+		.format(this.videoFormat)
 		.duration('0.1')
 		.input(':0.0+0,0')
 		.inputOptions([


### PR DESCRIPTION
While using screencap, I encountered an error when I tried to use the capturePipe function. This is because when streaming, ffmpeg needs a format, but in the implementation, the format was not provided. I have added the format